### PR TITLE
remove warnings for elixir v. 1.2.x

### DIFF
--- a/test/html_macros_test.exs
+++ b/test/html_macros_test.exs
@@ -4,7 +4,7 @@ defmodule WebAssembly.HTMLMacrosTest do
   use    WebAssembly
 
   WebAssembly.HTML.void_elements
-  |> Enum.each fn element ->
+  |> Enum.each( fn element ->
     test "#{element} test" do
       doc = builder do: unquote(element)(class: "foo")
       doc_no_attrs = builder do: unquote(element)()
@@ -12,10 +12,10 @@ defmodule WebAssembly.HTMLMacrosTest do
       assert doc == [["\n<#{e} ", [~s/class="foo"/], " />"]]
       assert doc_no_attrs == ["<#{e} />"]
     end
-  end
+  end)
 
   WebAssembly.HTML.nonvoid_elements
-  |> Enum.each fn element ->
+  |> Enum.each( fn element ->
     test "#{element} test" do
       doc = builder do: unquote(element)([class: "foo"], "content")
       doc_no_attrs = builder do: unquote(element)("content")
@@ -25,5 +25,5 @@ defmodule WebAssembly.HTMLMacrosTest do
       assert doc_no_attrs ==
         ["\n<#{e}>", "content", "</#{e}>"]
     end
-  end 
+  end)
 end


### PR DESCRIPTION
problem: 
- test/html_macros_test.exs:7: warning: you are piping into a function call without parentheses, which may be ambiguous.

solution: 
- wrap params to Enum.each in parentheses